### PR TITLE
Fix syntax according latest bitbake version

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILE_COLLECTIONS += "synopsys-layer"
 BBFILE_PATTERN_synopsys-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_synopsys-layer = "6"
 
-LAYERSERIES_COMPAT_synopsys-layer = " gatesgarth hardknott"
+LAYERSERIES_COMPAT_synopsys-layer = " honister"
 
 TOOLCHAIN_arc = "gcc"

--- a/conf/machine/hsdk.conf
+++ b/conf/machine/hsdk.conf
@@ -7,7 +7,7 @@ KERNEL_IMAGETYPE = "uImage"
 WKS_FILE ?= "sdimage-bootpart.wks"
 IMAGE_FSTYPES += "wic"
 IMAGE_BOOT_FILES ?= "uImage uboot.env"
-IMAGE_INSTALL_append += " u-boot"
+IMAGE_INSTALL:append += " u-boot"
 
 UBOOT_MACHINE ?= "hsdk_defconfig"
 

--- a/conf/machine/include/arch-arc.inc
+++ b/conf/machine/include/arch-arc.inc
@@ -2,7 +2,7 @@ TUNEVALID[bigendian] = "Enable big-endian mode"
 
 TUNE_ARCH = "${@bb.utils.contains('TUNE_FEATURES', 'bigendian', 'arceb', 'arc', d)}"
 
-MACHINE_FEATURES_BACKFILL_CONSIDERED_append = " qemu-usermode"
+MACHINE_FEATURES_BACKFILL_CONSIDERED:append = " qemu-usermode"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-arc"
 

--- a/conf/machine/include/tune-arcv2.inc
+++ b/conf/machine/include/tune-arcv2.inc
@@ -23,17 +23,17 @@ TUNE_CCARGS .= "${@bb.utils.contains('TUNE_FEATURES', 'fpud_all', ' -mfpu=fpud_a
 
 AVAILTUNES += "archs hs38 hs38_linux"
 
-TUNE_FEATURES_tune-archs = "hs llsc64 div_rem mpy"
+TUNE_FEATURES:tune-archs = "hs llsc64 div_rem mpy"
 TUNE_PKGARCH_tune-archs = "archs"
-PACKAGE_EXTRA_ARCHS_tune-archs = "archs hs38 hs38_linux"
+PACKAGE_EXTRA_ARCHS:tune-archs = "archs hs38 hs38_linux"
 
-TUNE_FEATURES_tune-hs38 = "hs llsc64 div_rem plus_qmacw"
+TUNE_FEATURES:tune-hs38 = "hs llsc64 div_rem plus_qmacw"
 TUNE_PKGARCH_tune-hs38 = "hs38"
-PACKAGE_EXTRA_ARCHS_tune-hs38 = "hs38 hs38_linux"
+PACKAGE_EXTRA_ARCHS:tune-hs38 = "hs38 hs38_linux"
 
-TUNE_FEATURES_tune-hs38_linux = "hs llsc64 div_rem plus_qmacw fpud_all"
+TUNE_FEATURES:tune-hs38_linux = "hs llsc64 div_rem plus_qmacw fpud_all"
 TUNE_PKGARCH_tune-hs38_linux = "hs38_linux"
-PACKAGE_EXTRA_ARCHS_tune-hs38_linux = "hs38_linux"
+PACKAGE_EXTRA_ARCHS:tune-hs38_linux = "hs38_linux"
 
 def arc_machine_dict(machdata, d):
     machdata = {

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://uboot.env.txt"
 

--- a/recipes-devtools/binutils/binutils-crosssdk_arc.bb
+++ b/recipes-devtools/binutils/binutils-crosssdk_arc.bb
@@ -8,6 +8,6 @@ PROVIDES = "virtual/${TARGET_PREFIX}binutils-crosssdk"
 
 SRC_URI += "file://0001-binutils-crosssdk-Generate-relocatable-SDKs.patch"
 
-do_configure_prepend () {
+do_configure:prepend () {
 	sed -i 's#/usr/local/lib /lib /usr/lib#${SDKPATHNATIVE}/lib ${SDKPATHNATIVE}/usr/lib /usr/local/lib /lib /usr/lib#' ${S}/ld/configure.tgt
 }

--- a/recipes-devtools/binutils/binutils_arc.bb
+++ b/recipes-devtools/binutils/binutils_arc.bb
@@ -10,7 +10,7 @@ EXTRA_OECONF += "--with-sysroot=/ \
                 --with-system-zlib \
                 "
 
-EXTRA_OEMAKE_append_libc-musl = "\
+EXTRA_OEMAKE:append:libc-musl = "\
                                  gt_cv_func_gnugettext1_libc=yes \
                                  gt_cv_func_gnugettext2_libc=yes \
                                 "
@@ -29,8 +29,8 @@ PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'debuginfod', d)}"
 PACKAGECONFIG[debuginfod] = "--with-debuginfod, --without-debuginfod, elfutils"
 # gcc9.0 end up mis-compiling libbfd.so with O2 which then crashes on target
 # So remove -O2 and use -Os as workaround
-SELECTED_OPTIMIZATION_remove_mipsarch = "-O2"
-SELECTED_OPTIMIZATION_append_mipsarch = " -Os"
+SELECTED_OPTIMIZATION:remove:mipsarch = "-O2"
+SELECTED_OPTIMIZATION:append:mipsarch = " -Os"
 
 do_install_class-native () {
 	autotools_do_install
@@ -64,10 +64,10 @@ PACKAGE_BEFORE_PN += "libbfd libopcodes"
 FILES_libbfd = "${libdir}/libbfd-*.so.* ${libdir}/libbfd-*.so"
 FILES_libopcodes = "${libdir}/libopcodes-*.so.* ${libdir}/libopcodes-*.so"
 
-SRC_URI_append_class-nativesdk =  " file://0003-binutils-nativesdk-Search-for-alternative-ld.so.conf.patch "
+SRC_URI:append:class-nativesdk =  " file://0003-binutils-nativesdk-Search-for-alternative-ld.so.conf.patch "
 
-USE_ALTERNATIVES_FOR_class-nativesdk = ""
-FILES_${PN}_append_class-nativesdk = " ${bindir}"
+USE_ALTERNATIVES_FOR:class-nativesdk = ""
+FILES_${PN}:append:class-nativesdk = " ${bindir}"
 
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-devtools/gdb/gdb_arc.bb
+++ b/recipes-devtools/gdb/gdb_arc.bb
@@ -3,7 +3,7 @@ require recipes-devtools/gdb/gdb-${PV}.inc
 
 inherit python3-dir
 
-EXTRA_OEMAKE_append_libc-musl = "\
+EXTRA_OEMAKE:append:libc-musl = "\
                                  gt_cv_func_gnugettext1_libc=yes \
                                  gt_cv_func_gnugettext2_libc=yes \
                                  gl_cv_func_working_strerror=yes \
@@ -11,7 +11,7 @@ EXTRA_OEMAKE_append_libc-musl = "\
                                  gl_cv_func_gettimeofday_clobber=no \
                                 "
 
-do_configure_prepend() {
+do_configure:prepend() {
 	if [ "${@bb.utils.filter('PACKAGECONFIG', 'python', d)}" ]; then
 		cat > ${WORKDIR}/python << EOF
 #!/bin/sh
@@ -26,4 +26,4 @@ EOF
 		chmod +x ${WORKDIR}/python
 	fi
 }
-CPPFLAGS_append_libc-musl = " -Drpl_gettimeofday=gettimeofday -Drpl_stat=stat"
+CPPFLAGS:append:libc-musl = " -Drpl_gettimeofday=gettimeofday -Drpl_stat=stat"

--- a/recipes-kernel/linux/linux-arc.inc
+++ b/recipes-kernel/linux/linux-arc.inc
@@ -12,13 +12,13 @@ SRC_URI = "\
 S = "${WORKDIR}/linux-${PV}"
 
 DEPENDS += " libgcc"
-KERNEL_CC_append = " ${TOOLCHAIN_OPTIONS}"
+KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"
 
-KERNEL_DEFCONFIG_axs101 = "axs101"
-KERNEL_DEFCONFIG_axs103 = "axs103_smp"
-KERNEL_DEFCONFIG_hsdk = "hsdk"
-KERNEL_DEFCONFIG_nsim700 = "nsim_700"
-KERNEL_DEFCONFIG_hapshs = "haps_hs"
+KERNEL_DEFCONFIG:axs101 = "axs101"
+KERNEL_DEFCONFIG:axs103 = "axs103_smp"
+KERNEL_DEFCONFIG:hsdk = "hsdk"
+KERNEL_DEFCONFIG:nsim700 = "nsim_700"
+KERNEL_DEFCONFIG:hapshs = "haps_hs"
 
 KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} ${KERNEL_DEFCONFIG}_defconfig"
 

--- a/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,8 +1,8 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-COMPATIBLE_MACHINE_append = "|hsdk|hapshs"
+COMPATIBLE_MACHINE:append = "|hsdk|hapshs"
 
-KERNEL_CC_append = " ${TOOLCHAIN_OPTIONS}"
+KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"
 
 SRC_URI += "\
     "


### PR DESCRIPTION
There was an update of syntax in bitbake, where variable separator "_" was replaced with ":".

Signed-off-by: Evgeniy Didin <Evgeniy.Didin@synopsys.com>